### PR TITLE
Add GitHub Actions workflow for Docker build and publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,74 @@
+name: Docker Build and Publish
+
+on:
+  push:
+    branches:
+      - main
+    # Only run on main pushes if relevant code/config files changed
+    paths:
+      - '**.py'
+      - 'pyproject.toml'
+      - 'poetry.lock'
+      - 'Dockerfile'
+      - '.github/workflows/**'
+      # Exclude documentation changes
+      - '!**.md'
+      - '!.gitignore'
+      - '!LICENSE'
+      - '!.env.example'
+  pull_request:
+    branches:
+      - main # Or specify branches PRs target if needed
+    # Run for PRs regardless of paths changed to ensure build succeeds
+
+# Permissions needed to push to GHCR
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          # Use the automatic GITHUB_TOKEN for authentication
+          username: ${{ github.repository_owner }} # Or github.actor
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Point to the public GHCR repo (use lowercase repository name)
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            # Tag 'latest' only for default branch (main) pushes
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            # Tag 'pr-<number>' for pull requests
+            type=raw,value=pr-${{ github.event.number }},enable=${{ github.event_name == 'pull_request' }}
+            # Tag with the commit SHA
+            type=sha
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          # Push is true only for main branch pushes and PRs (can adjust if needed)
+          # For PRs, this builds but doesn't strictly NEED to push, 
+          # but pushing with a PR tag can be useful for testing.
+          # Set push: ${{ github.event_name != 'pull_request' }} if you only want main pushes.
+          push: true 
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # Enable build cache
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 


### PR DESCRIPTION
- Created a new workflow file to automate Docker image building and publishing to GitHub Container Registry.
- Configured triggers for pushes to the main branch and pull requests, with specific path filters.
- Set up permissions and steps for checking out the repository, logging into the container registry, extracting metadata, and building the Docker image with caching enabled.